### PR TITLE
Fix errors, better response handling and adding `options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ The `variantId` fields value might need to be dynamic if your site allows the us
 
 If you only have one variant then use the example provided above.
 
+You can also include an `options` value to save additional information with the form submission. This should be in the form of a JSON object. This input is entirely optional.
+
+```twig
+{% set options = { title: 'Some Title', productAttribute: 'Some Value' } %}
+
+<input type="hidden" name="options" value="{{ options | json_encode }}">
+```
+
+You can use these variables in your email template, or subject line via `options.title` (as per the above example). Make sure you check to see if values exist when doing so!
+
 Check out the [helper template](./resources/templates/form-example.twig) (built using Tailwind) if you need some to get you started.
 
 ![Screenshot of form example](resources/img/form-example.png)

--- a/src/BackInStock.php
+++ b/src/BackInStock.php
@@ -50,7 +50,7 @@ class BackInStock extends Plugin
     /**
      * @var string
      */
-    public $schemaVersion = '0.1.0';
+    public $schemaVersion = '0.1.1';
 
     // Public Methods
     // =========================================================================

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -51,6 +51,7 @@ class BaseController extends Controller
         
         $email = $request->getParam('email');
         $variantId = $request->getParam('variantId');
+        $options = $request->getParam('options', []);
 
         if ($variantId == '' || !is_numeric($variantId)) {
             $error = Craft::t('craft-commerce-back-in-stock', 'Sorry you couldn\'t be added to the notifications list');
@@ -126,6 +127,7 @@ class BaseController extends Controller
         $model = new BackInStockModel();
         $model->variantId = $variantId;
         $model->email = $email;
+        $model->options = $options;
 
         if (!BackInStock::$plugin->backInStockService->createBackInStockRecord($model)) {
             $error = Craft::t('craft-commerce-back-in-stock', 'We couldn\'t save your request');

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -88,8 +88,39 @@ class BaseController extends Controller
 
         //check is product exists and is actually out of stock
         $variant = Variant::findOne($variantId);
-        if (!$variant || $variant->hasStock()) {
-            return false;
+
+        if (!$variant) {
+            $error = Craft::t('craft-commerce-back-in-stock', 'Unable to find variant');
+
+            if ($request->getAcceptsJson()) {
+                return $this->asJson([
+                    'success' => false,
+                    'error' => $error,
+                ]);
+            }
+
+            Craft::$app->getUrlManager()->setRouteParams([
+                'error' => $error,
+            ]);
+
+            return null;
+        }
+
+        if ($variant->hasStock()) {
+            $error = Craft::t('craft-commerce-back-in-stock', 'Variant is in stock!');
+
+            if ($request->getAcceptsJson()) {
+                return $this->asJson([
+                    'success' => false,
+                    'error' => $error,
+                ]);
+            }
+
+            Craft::$app->getUrlManager()->setRouteParams([
+                'error' => $error,
+            ]);
+
+            return null;
         }
 
         $model = new BackInStockModel();

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -53,12 +53,12 @@ class BaseController extends Controller
         $variantId = $request->getParam('variantId');
 
         if ($variantId == '' || !is_numeric($variantId)) {
-            $session->setError(Craft::t('Sorry you couldn\'t be added to the notifications list'));
+            $session->setError(Craft::t('craft-commerce-back-in-stock', 'Sorry you couldn\'t be added to the notifications list'));
             return false;
         }
 
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $session->setError(Craft::t('Please Enter a Valid Email Address'));
+            $session->setError(Craft::t('craft-commerce-back-in-stock', 'Please Enter a Valid Email Address'));
             return false;
         }
 

--- a/src/jobs/SendEmailNotification.php
+++ b/src/jobs/SendEmailNotification.php
@@ -60,7 +60,7 @@ class SendEmailNotification extends BaseJob
             $record->save();
         }
 
-        BackInStock::$plugin->backInStockService->sendMail($variant, $subject, $recipient, $template);
+        BackInStock::$plugin->backInStockService->sendMail($variant, $subject, $record, $recipient, $template);
         
     }
 

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -70,6 +70,7 @@ class Install extends Migration
                     'uid' => $this->uid(),
                     'email' => $this->string(255)->notNull()->defaultValue(''),
                     'variantId' => $this->integer()->notNull(),
+                    'options' => $this->text(),
                     'isNotified' => $this->boolean()->defaultValue(false),
                 ]
             );

--- a/src/migrations/m190609_000000_add_options_column.php
+++ b/src/migrations/m190609_000000_add_options_column.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Back In Stock plugin for Craft CMS 3.x
+ *
+ * Back in stock Craft Commerce 2 plugin
+ *
+ * @link      https://www.mylesderham.dev/
+ * @copyright Copyright (c) 2019 Myles Derham
+ */
+
+namespace mediabeastnz\backinstock\migrations;
+
+use mediabeastnz\backinstock\BackInStock;
+
+use craft\db\Migration;
+use craft\db\Query;
+
+use yii\db\Expression;
+
+class m190609_000000_add_options_column extends Migration
+{
+    public function safeUp()
+    {   
+        if (!$this->db->columnExists('{{%backinstock_records}}', 'options')) {
+            $this->addColumn('{{%backinstock_records}}', 'options', $this->text()->after('variantId'));
+        }
+
+        return true;
+    }
+
+    public function safeDown()
+    {
+        echo "m190609_000000_add_options_column cannot be reverted.\n";
+
+        return false;
+    }
+}

--- a/src/models/BackInStockModel.php
+++ b/src/models/BackInStockModel.php
@@ -14,6 +14,7 @@ use mediabeastnz\backinstock\BackInStock;
 
 use Craft;
 use craft\base\Model;
+use craft\helpers\Json;
 
 /**
  * @author    Myles Derham
@@ -33,6 +34,8 @@ class BackInStockModel extends Model
 
     public $variantId;
 
+    public $options;
+
     public $isNotified;
 
     public $uid;
@@ -44,6 +47,18 @@ class BackInStockModel extends Model
 
     // Public Methods
     // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    public function init()
+    {
+        parent::init();
+
+        if (is_string($this->options)) {
+            $this->options = Json::decode($this->options);
+        }
+    }
 
     /**
      * @inheritdoc

--- a/src/services/BackInStockService.php
+++ b/src/services/BackInStockService.php
@@ -17,6 +17,7 @@ use mediabeastnz\backinstock\jobs\SendEmailNotification;
 
 use Craft;
 use craft\base\Component;
+use craft\helpers\Json;
 use craft\mail\Message;
 use craft\commerce\elements\Variant;
 
@@ -94,6 +95,7 @@ class BackInStockService extends Component
             $record = BackInStockRecord::findOne(array(
                 'variantId' => $model->variantId, 
                 'email' => $model->email,
+                'options' => $model->options,
                 'isNotified' => 0
             ));
 
@@ -102,6 +104,7 @@ class BackInStockService extends Component
                 $newRecord = new BackInStockRecord();
                 $newRecord->variantId = $model->variantId;
                 $newRecord->email = $model->email;
+                $newRecord->options = $model->options;
                 $newRecord->save();
 
                 return true;
@@ -119,7 +122,7 @@ class BackInStockService extends Component
      * @param AbandonedCart $cart
      * @return bool $result
      */
-    public function sendMail($variantId, $subject, $recipient = null, $templatePath = null): bool
+    public function sendMail($variantId, $subject, $record = null, $recipient = null, $templatePath = null): bool
     {        
         // settings/defaults
         $view = Craft::$app->getView();
@@ -146,8 +149,13 @@ class BackInStockService extends Component
         // template variables
         $renderVariables = [
             'subject' => $subject,
-            'variant' => $variant
+            'variant' => $variant,
         ];
+
+        // Add the record options, if available
+        if ($record && is_string($record->options)) {
+            $renderVariables['options'] = Json::decode($record->options);
+        }
 
         $templatePath = $view->renderString($templatePath, $renderVariables);
 


### PR DESCRIPTION
A few things in this PR, firstly there's an error when trying to submit the form (with no email), in that there's some invalid `Craft::t()` calls.

I've also added better (albeit verbose) handling of responses to the controller. It should now support Ajax requests nicely, but also traditional form submissions, giving access to an `error` variable. I don't believe using session error/info's are the right approach, being largely CP-based. Also added an error message for if an invalid variant, or if its already in stock.

I've also added a new column to saved submissions called options. For the particular site I'm working on, we need to store some additional information not related to the variant, so we can use it in the emails and subject. I'm sure other people would find it useful as well, as it can be used for a variety of things.

Not included here, but I'd also recommend an error message is thrown when the user is already subscribed to the notification. Right now, it just errors out, giving no reason.