### PR TITLE
Fixed bug where multiple notification emails could be sent unintentionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The form will need 3 fields. 2 hidden fields and 1 visible field where the user 
 
 ```twig
 <input type="hidden" name="action" value="craft-commerce-back-in-stock/base/register-interest">
-<input type="text" name="variantId" value="{{product.defaultVariant.id}}">
+<input type="hidden" name="variantId" value="{{ product.defaultVariant.id }}">
 <input type="text" name="email" value="{{ currentUser.email }}">
 ```
 
@@ -50,4 +50,3 @@ You can use these variables in your email template, or subject line via `options
 Check out the [helper template](./resources/templates/form-example.twig) (built using Tailwind) if you need some to get you started.
 
 ![Screenshot of form example](resources/img/form-example.png)
-

--- a/src/BackInStock.php
+++ b/src/BackInStock.php
@@ -18,6 +18,7 @@ use mediabeastnz\backinstock\models\Settings;
 use Craft;
 use craft\base\Plugin;
 use craft\services\Plugins;
+use craft\events\ModelEvent;
 use craft\events\PluginEvent;
 use craft\web\UrlManager;
 use craft\events\RegisterUrlRulesEvent;
@@ -80,10 +81,10 @@ class BackInStock extends Plugin
             __METHOD__
         );
 
-        Event::on(Elements::class, Elements::EVENT_BEFORE_SAVE_ELEMENT, function(Event $event) {
-
-            if ($event->element instanceof Variant) {
-                $this->backInStockService->findVariantsInStock($event->element);
+        Event::on(Variant::class, Variant::EVENT_BEFORE_SAVE, function(ModelEvent $event) {
+            $variant = $event->sender;
+            if ($variant->stock > 0 || $variant->hasUnlimitedStock) {
+                $this->backInStockService->isBackInStock($variant);
             }
         });
 

--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -43,12 +43,12 @@ class BaseController extends Controller
      */
     public function actionRegisterInterest()
     {
-        
+
         $this->requirePostRequest();
 
         $session = Craft::$app->getSession();
         $request = Craft::$app->getRequest();
-        
+
         $email = $request->getParam('email');
         $variantId = $request->getParam('variantId');
         $options = $request->getParam('options', []);
@@ -63,15 +63,13 @@ class BaseController extends Controller
                 ]);
             }
 
-            Craft::$app->getUrlManager()->setRouteParams([
-                'error' => $error,
-            ]);
+            Craft::$app->getSession()->setError($error);
 
             return null;
         }
 
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-            $error = Craft::t('craft-commerce-back-in-stock', 'Please Enter a Valid Email Address');
+            $error = Craft::t('craft-commerce-back-in-stock', 'Please enter a valid email address');
 
             if ($request->getAcceptsJson()) {
                 return $this->asJson([
@@ -80,9 +78,7 @@ class BaseController extends Controller
                 ]);
             }
 
-            Craft::$app->getUrlManager()->setRouteParams([
-                'error' => $error,
-            ]);
+            Craft::$app->getSession()->setError($error);
 
             return null;
         }
@@ -100,9 +96,7 @@ class BaseController extends Controller
                 ]);
             }
 
-            Craft::$app->getUrlManager()->setRouteParams([
-                'error' => $error,
-            ]);
+            Craft::$app->getSession()->setError($error);
 
             return null;
         }
@@ -117,9 +111,7 @@ class BaseController extends Controller
                 ]);
             }
 
-            Craft::$app->getUrlManager()->setRouteParams([
-                'error' => $error,
-            ]);
+            Craft::$app->getSession()->setError($error);
 
             return null;
         }
@@ -139,9 +131,7 @@ class BaseController extends Controller
                 ]);
             }
 
-            Craft::$app->getUrlManager()->setRouteParams([
-                'error' => $error,
-            ]);
+            Craft::$app->getSession()->setError($error);
 
             return null;
         }

--- a/src/services/BackInStockService.php
+++ b/src/services/BackInStockService.php
@@ -74,12 +74,12 @@ class BackInStockService extends Component
             $record = BackInStockRecord::findOne(array(
                 'variantId' => $model->variantId,
                 'email' => $model->email,
-                'options' => $model->options,
+                'options' => json_encode($model->options),
                 'isNotified' => 0
             ));
 
             if (!$record) {
-                // record deosn't exist so create it
+                // record doesn't exist so create it
                 $newRecord = new BackInStockRecord();
                 $newRecord->variantId = $model->variantId;
                 $newRecord->email = $model->email;


### PR DESCRIPTION
When a product is saved, a save event is triggered for each variant of that product. As a result, this causes the plugin to send multiple emails for the same variant in some circumstances. For example, if a user requested a back in stock notification for the third out of three variants and it was returned to stock, the plugin would fire three notification emails, because during saving the first two variants the third variant is still not saved yet. I've updated the code to check each variant individually since they are saved individually. 