### PR TITLE
Automatically purge DB records

### DIFF
--- a/src/jobs/SendEmailNotification.php
+++ b/src/jobs/SendEmailNotification.php
@@ -29,16 +29,6 @@ class SendEmailNotification extends BaseJob
      * @var int
      */
     public $backInStockRecordId;
-    
-    /**
-     * @var int
-     */
-    public $variantId;
-
-    /**
-     * @var string
-     */
-    public $email;
 
     // Public Methods
     // =========================================================================
@@ -51,17 +41,18 @@ class SendEmailNotification extends BaseJob
 
         $template = BackInStock::$plugin->getSettings()->emailTemplate;
         $subject = BackInStock::$plugin->getSettings()->emailSubject;
-        $recipient = $this->email;
-        $variant = $this->variantId;
 
         $record = BackInStockRecord::findOne($this->backInStockRecordId);
         if ($record) {
-            $record->isNotified = 1;
-            $record->save();
+            if (BackInStock::$plugin->backInStockService->sendMail($record, $subject, $template)) {
+                if (BackInStock::$plugin->getSettings()->purgeRequests) {
+                    $record->delete();
+                } else {
+                    $record->isNotified = 1;
+                    $record->save();
+                }
+            }
         }
-
-        BackInStock::$plugin->backInStockService->sendMail($variant, $subject, $record, $recipient, $template);
-        
     }
 
     // Protected Methods

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -34,6 +34,11 @@ class Settings extends Model
      */
     public $emailSubject = 'Order today, {{variant.title}} is now in stock';
 
+    /**
+     * @var bool
+     */
+    public $purgeRequests = false;
+
     // Public Methods
     // =========================================================================
 
@@ -44,6 +49,7 @@ class Settings extends Model
     {
         return [
             [['emailTemplate', 'emailSubject'], 'string'],
+            ['purgeRequests', 'boolean'],
             [['emailTemplate', 'emailSubject'], 'required']
         ];
     }

--- a/src/services/BackInStockService.php
+++ b/src/services/BackInStockService.php
@@ -57,9 +57,7 @@ class BackInStockService extends Component
             // add all emails to send to the queue
             foreach ($records as $record) {
                 Craft::$app->queue->push(new SendEmailNotification([
-                    'backInStockRecordId' => $record->id,
-                    'variantId' => $record->variantId,
-                    'email' => $record->email
+                    'backInStockRecordId' => $record->id
                 ]));
             }
         }
@@ -95,13 +93,7 @@ class BackInStockService extends Component
     }
 
 
-    /**
-     * Send the abandoned cart reminder email.
-     *
-     * @param AbandonedCart $cart
-     * @return bool $result
-     */
-    public function sendMail($variantId, $subject, $record = null, $recipient = null, $templatePath = null): bool
+    public function sendMail($record, $subject, $templatePath = null): bool
     {
         // settings/defaults
         $view = Craft::$app->getView();
@@ -115,7 +107,7 @@ class BackInStockService extends Component
         }
 
         // get the order from the cart
-        $variant = Variant::findOne($variantId);
+        $variant = Variant::findOne($record->variantId);
 
         if (!$variant) {
             $error = Craft::t('craft-commerce-back-in-stock', 'Could not find Variant for Back In Stock Notification email.');
@@ -155,7 +147,7 @@ class BackInStockService extends Component
         // build the email
         $newEmail = new Message();
         $newEmail->setFrom([Craft::parseEnv($settings['fromEmail']) => Craft::parseEnv($settings['fromName'])]);
-        $newEmail->setTo($recipient);
+        $newEmail->setTo($record->email);
         $newEmail->setSubject($view->renderString($subject, $renderVariables));
         $newEmail->setHtmlBody($view->renderTemplate($templatePath, $renderVariables));
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -29,3 +29,11 @@
     placeholder: 'Order today, {{variant.title}} is now in stock',
     errors: settings.getErrors('emailSubject')
 }) }}
+
+{{ forms.lightswitchField({
+    first: false,
+    label: "Automatically Purge Notification Requests",
+    instructions: 'Purge notification requests from the database when a notification is successfully sent.',
+    name: 'purgeRequests',
+    on: settings.purgeRequests
+}) }}


### PR DESCRIPTION
Hey @mediabeastnz, thanks for the quick turnaround on my previous pull request. Sorry to ping you again in such a short time period, but I'm wondering if you could merge an additional feature. I added a setting that gives the option to automatically purge DB records after a notification is sent rather than marking them as notified. With GDPR, CCPA, and more privacy acts to come, the less personal information we keep on our servers, the better. Thanks for your consideration!