### PR TITLE
Fixed duplicate entries

### DIFF
--- a/src/services/BackInStockService.php
+++ b/src/services/BackInStockService.php
@@ -79,7 +79,7 @@ class BackInStockService extends Component
             $record = BackInStockRecord::findOne(array(
                 'variantId' => $model->variantId,
                 'email' => $model->email,
-                'options' => $model->options,
+                'options' => json_encode($model->options),
                 'isNotified' => 0
             ));
 


### PR DESCRIPTION
`$record` would always be `null`. Wrapped `json_encode` around the options of the model.