### PR TITLE
Fix duplicate entries when options are supplied

### DIFF
--- a/src/controllers/BaseController.php
+++ b/src/controllers/BaseController.php
@@ -56,7 +56,7 @@ class BaseController extends Controller
 
         $email = $request->getParam('email');
         $variantId = $request->getParam('variantId');
-        $options = $request->getParam('options', []);
+        $options = $request->getParam('options', json_encode([]));
         $locale = Craft::$app->language;
 
         if ($variantId == '' || !is_numeric($variantId)) {

--- a/src/services/BackInStockService.php
+++ b/src/services/BackInStockService.php
@@ -81,7 +81,7 @@ class BackInStockService extends Component
                 'variantId' => $model->variantId,
                 'locale' => $model->locale,
                 'email' => $model->email,
-                'options' => json_encode($model->options),
+                'options' => $model->options,
                 'isNotified' => 0
             ));
 


### PR DESCRIPTION
The previous fix for duplicate entries (#8) fixed the issue for entries without options, but introduced it to entries containing options. This fixes the problem for both situations.